### PR TITLE
feat: 319440 Add data encryption flow

### DIFF
--- a/src/aurora/api/renderers.py
+++ b/src/aurora/api/renderers.py
@@ -1,0 +1,50 @@
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework.renderers import BaseRenderer
+
+logger = logging.getLogger(__name__)
+
+ENCRYPTED_MEDIA_TYPE = "application/encrypted+json"
+
+
+class EncryptedJSONRenderer(BaseRenderer):
+    """
+    DRF renderer that Fernet-encrypts the full JSON response payload.
+
+    Activated via DRF content-type negotiation when the client sends:
+        Accept: application/encrypted+json
+
+    Requires ``AURORA_PAYLOAD_ENCRYPTION_KEY`` to be set in Django settings.
+    The encrypted wire format is a JSON object with a single ``payload`` field:
+        {"payload": "<fernet_token>"}
+
+    The token is a URL-safe base64-encoded Fernet ciphertext that the consumer
+    must decrypt using the same pre-shared key.
+    """
+
+    media_type = ENCRYPTED_MEDIA_TYPE
+    format = "encrypted_json"
+    charset = None
+
+    def render(
+        self,
+        data: Any,
+        accepted_media_type: str | None = None,
+        renderer_context: Mapping[str, Any] | None = None,
+    ) -> bytes:
+        key: str = getattr(settings, "AURORA_PAYLOAD_ENCRYPTION_KEY", "")
+        if not key:
+            raise ImproperlyConfigured(
+                "AURORA_PAYLOAD_ENCRYPTION_KEY must be configured to serve encrypted API responses. "
+                "Generate a key with: "
+                'python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+            )
+        json_bytes = json.dumps(data).encode("utf-8")
+        token: bytes = Fernet(key).encrypt(json_bytes)
+        return json.dumps({"payload": token.decode("utf-8")}).encode("utf-8")

--- a/src/aurora/api/viewsets/registration.py
+++ b/src/aurora/api/viewsets/registration.py
@@ -23,6 +23,7 @@ from rest_framework.serializers import Serializer
 
 from ...core.utils import build_dict, get_etag, get_session_id
 from ...registration.models import Record, Registration
+from ..renderers import EncryptedJSONRenderer
 from ..serializers import (
     RegistrationDetailSerializer,
     RegistrationListSerializer,
@@ -112,7 +113,7 @@ class RegistrationViewSet(SmartViewSet):
     @action(
         detail=True,
         methods=["GET"],
-        renderer_classes=[JSONRenderer],
+        renderer_classes=[JSONRenderer, EncryptedJSONRenderer],
         pagination_class=RecordPageNumberPagination,
         filter_backends=[DjangoFilterBackend],
     )

--- a/src/aurora/config/__init__.py
+++ b/src/aurora/config/__init__.py
@@ -56,6 +56,7 @@ OPTIONS = {
     "EXTRA_AUTHENTICATION_BACKENDS": (list, []),
     "EXTRA_INSTALLED_APPS": (list, []),
     "EXTRA_MIDDLEWARES": (list, []),
+    "AURORA_PAYLOAD_ENCRYPTION_KEY": (str, "", "", False, "Pre-shared Fernet key for encrypting API response"),
     "FERNET_KEY": (str, "", uuid.uuid4().hex, True),
     "FRONT_DOOR_ALLOWED_PATHS": (str, ".*"),
     "FRONT_DOOR_ENABLED": (bool, False),

--- a/src/aurora/config/settings.py
+++ b/src/aurora/config/settings.py
@@ -18,6 +18,7 @@ DEV_DIR = SRC_DIR.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")
 FERNET_KEY = env("FERNET_KEY")
+AURORA_PAYLOAD_ENCRYPTION_KEY = env("AURORA_PAYLOAD_ENCRYPTION_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG: bool = env("DEBUG")

--- a/tests/api/test_api_encrypted_renderer.py
+++ b/tests/api/test_api_encrypted_renderer.py
@@ -1,0 +1,123 @@
+import json
+
+import pytest
+from cryptography.fernet import Fernet
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework.test import APIClient
+from testutils.factories import RecordFactory, RegistrationFactory, TokenProxyFactory
+
+from aurora.api.renderers import EncryptedJSONRenderer
+
+
+@pytest.fixture
+def encryption_key():
+    return Fernet.generate_key()
+
+
+@pytest.fixture
+def renderer():
+    return EncryptedJSONRenderer()
+
+
+@pytest.fixture
+def registration(simple_form):
+    reg = RegistrationFactory(flex_form=simple_form)
+    RecordFactory.create_batch(size=3, registration=reg)
+    return reg
+
+
+@pytest.fixture
+def client(admin_user):
+    api_client = APIClient()
+    token = TokenProxyFactory(user=admin_user)
+    api_client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+    return api_client
+
+
+def test_renderer_media_type(renderer):
+    assert renderer.media_type == "application/encrypted+json"
+
+
+def test_renderer_format(renderer):
+    assert renderer.format == "encrypted_json"
+
+
+def test_renderer_encrypts_output(renderer, encryption_key, settings):
+    settings.AURORA_PAYLOAD_ENCRYPTION_KEY = encryption_key
+    data = {"results": [{"pk": 1, "fields": {"name": "Alice"}}], "count": 1, "next": None}
+
+    output: bytes = renderer.render(data)
+
+    outer = json.loads(output)
+    assert "payload" in outer
+    assert isinstance(outer["payload"], str)
+
+
+def test_renderer_round_trip(renderer, encryption_key, settings):
+    settings.AURORA_PAYLOAD_ENCRYPTION_KEY = encryption_key
+    original = {"results": [{"pk": 42, "fields": {"foo": "bar"}}], "count": 1, "next": None}
+
+    output: bytes = renderer.render(original)
+
+    outer = json.loads(output)
+    token = outer["payload"].encode("utf-8")
+    plaintext = Fernet(encryption_key).decrypt(token)
+    recovered = json.loads(plaintext)
+    assert recovered == original
+
+
+def test_renderer_raises_when_key_not_configured(renderer, settings):
+    settings.AURORA_PAYLOAD_ENCRYPTION_KEY = ""
+
+    with pytest.raises(ImproperlyConfigured, match="AURORA_PAYLOAD_ENCRYPTION_KEY"):
+        renderer.render({"results": []})
+
+
+def test_renderer_raises_when_key_attribute_absent(renderer, settings):
+    if hasattr(settings, "AURORA_PAYLOAD_ENCRYPTION_KEY"):
+        delattr(settings, "AURORA_PAYLOAD_ENCRYPTION_KEY")
+
+    with pytest.raises(ImproperlyConfigured, match="AURORA_PAYLOAD_ENCRYPTION_KEY"):
+        renderer.render({"results": []})
+
+
+def test_renderer_output_is_bytes(renderer, encryption_key, settings):
+    settings.AURORA_PAYLOAD_ENCRYPTION_KEY = encryption_key
+
+    output = renderer.render([1, 2, 3])
+
+    assert isinstance(output, bytes)
+
+
+@pytest.mark.django_db
+def test_records_endpoint_returns_encrypted_payload(registration, client, settings, encryption_key):
+    """Integration: the records endpoint honours Accept: application/encrypted+json."""
+    settings.AURORA_PAYLOAD_ENCRYPTION_KEY = encryption_key
+
+    res = client.get(
+        f"/api/registration/{registration.pk}/records/",
+        HTTP_ACCEPT="application/encrypted+json",
+    )
+
+    assert res.status_code == 200
+    assert "application/encrypted+json" in res.headers.get("Content-Type", "")
+    outer = json.loads(res.content)
+    assert "payload" in outer
+
+    token = outer["payload"].encode("utf-8")
+    plaintext = Fernet(encryption_key).decrypt(token)
+    data = json.loads(plaintext)
+    assert "results" in data
+
+
+@pytest.mark.django_db
+def test_records_endpoint_plain_json_without_accept_header(registration, client, settings, encryption_key):
+    """Without encrypted Accept header the response is plain JSON (backward compat)."""
+    settings.AURORA_PAYLOAD_ENCRYPTION_KEY = encryption_key
+
+    res = client.get(f"/api/registration/{registration.pk}/records/", format="json")
+
+    assert res.status_code == 200
+    data = res.json()
+    assert "results" in data
+    assert "payload" not in data


### PR DESCRIPTION
[AB#319440](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/319440)

Adds encrypted responses to `GET /api/registration/{id}/records/` using a new `EncryptedJSONRenderer`. When a client sends `Accept: application/encrypted+json`, the full response body is Fernet-encrypted with a pre-shared key (`AURORA_PAYLOAD_ENCRYPTION_KEY`) and returned as `{"payload": "<token>"}`. Clients without the header continue to receive plain JSON — no breaking changes.